### PR TITLE
dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,8 +40,4 @@ updates:
   - package-ecosystem: "devcontainers" # See documentation for possible values
     directory: "/"
     schedule:
-      interval: "daily"      
-groups:
-  all:
-    patterns:
-      - "*"
+      interval: "daily"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The `groups` section, which previously contained a pattern to include all directories, has been removed. This suggests that Dependabot will no longer group updates together, but will create separate pull requests for each update.