### PR TITLE
adding #checkov:skip=CKV_AZURE_50: "Ensure Azure Storage Account stor…

### DIFF
--- a/quickstarts/301-sap-gateway/storage-account/main.tf
+++ b/quickstarts/301-sap-gateway/storage-account/main.tf
@@ -50,6 +50,7 @@ resource "azurerm_storage_account" "storage_account" {
   #checkov:skip=CKV2_AZURE_41: "Ensure storage account is configured with SAS expiration policy, this require correct accesss permisions in the subscription"
   #checkov:skip=CKV2_AZURE_33: "Ensure storage account is configured with private endpoint, this deployment requires public access to the blob"
   #checkov:skip=CKV2_AZURE_1: "Ensure storage for critical data are encrypted with Customer Managed Key, KMK is not implemented in this deployment du to a lack of permissions in the subscription"
+  #checkov:skip=CKV_AZURE_50: "Ensure Azure Storage Account storing Machine Learning workspace high business impact data is not publicly accessible"
 }
 
 resource "azurerm_storage_container" "storage_container_installs" {

--- a/quickstarts/301-sap-gateway/storage-account/main.tf
+++ b/quickstarts/301-sap-gateway/storage-account/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_storage_account" "storage_account" {
     default_action = "Allow" // this feature needs to be changed to be"Deny"
     #checkov:skip=CKV_AZURE_59: "Ensure that Storage accounts disallow public access, this deployment requires public access to the storage account"
     #checkov:skip=CKV_AZURE_35: "Ensure default network access rule for Storage Accounts is set to deny"
-    #checkov:skip=CKV_AZURE_50: "Ensure Azure Storage Account storing Machine Learning workspace high business impact data is not publicly accessible"
+    #checkov:skip=CKV2_AZURE_50: "Ensure Azure Storage Account storing Machine Learning workspace high business impact data is not publicly accessible"
     bypass = ["AzureServices", "Logging", "Metrics"]
   }
   tags = var.tags
@@ -50,7 +50,6 @@ resource "azurerm_storage_account" "storage_account" {
   #checkov:skip=CKV2_AZURE_41: "Ensure storage account is configured with SAS expiration policy, this require correct accesss permisions in the subscription"
   #checkov:skip=CKV2_AZURE_33: "Ensure storage account is configured with private endpoint, this deployment requires public access to the blob"
   #checkov:skip=CKV2_AZURE_1: "Ensure storage for critical data are encrypted with Customer Managed Key, KMK is not implemented in this deployment du to a lack of permissions in the subscription"
-  #checkov:skip=CKV_AZURE_50: "Ensure Azure Storage Account storing Machine Learning workspace high business impact data is not publicly accessible"
 }
 
 resource "azurerm_storage_container" "storage_container_installs" {

--- a/quickstarts/301-sap-gateway/storage-account/main.tf
+++ b/quickstarts/301-sap-gateway/storage-account/main.tf
@@ -38,6 +38,7 @@ resource "azurerm_storage_account" "storage_account" {
     default_action = "Allow" // this feature needs to be changed to be"Deny"
     #checkov:skip=CKV_AZURE_59: "Ensure that Storage accounts disallow public access, this deployment requires public access to the storage account"
     #checkov:skip=CKV_AZURE_35: "Ensure default network access rule for Storage Accounts is set to deny"
+    #checkov:skip=CKV_AZURE_50: "Ensure Azure Storage Account storing Machine Learning workspace high business impact data is not publicly accessible"
     bypass = ["AzureServices", "Logging", "Metrics"]
   }
   tags = var.tags


### PR DESCRIPTION
Adding exception for Storage account check:

#checkov:skip=CKV_AZURE_50: "Ensure Azure Storage Account storing Machine Learning workspace high business impact data is not publicly accessible"

This pull request includes a change to the `resource "azurerm_storage_account" "storage_account"` block in the `quickstarts/301-sap-gateway/storage-account/main.tf` file. The change adds a new checkov skip rule (`CKV_AZURE_50`) to ensure that the Azure Storage Account storing Machine Learning workspace high business impact data is not publicly accessible. This is an important security measure to protect sensitive data.