### PR TITLE
adding --use-device-code in bootstrap file

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -36,7 +36,7 @@ if [ "$#" -eq 4 ]; then
         exit 1
     fi
 
-    az login
+    az login --use-device-code
     az account set --subscription $subscription_id
 
     echo "Using the following subscription:"


### PR DESCRIPTION
This pull request includes a modification to the `bootstrap/bootstrap.sh` script. The change modifies the Azure login command to use device code for authentication.

In detail, the change is:

* [`bootstrap/bootstrap.sh`](diffhunk://#diff-d3cdbc0e4f313c8e281d50203043b86bd81bddf1463cff682a35d1d447205220L39-R39): Replaced `az login` with `az login --use-device-code` to switch to device code authentication when logging into Azure.