### PR TITLE
use device code in bootstrap

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -36,7 +36,7 @@ if [ "$#" -eq 4 ]; then
         exit 1
     fi
 
-    az login
+    az login --use-device-code
     az account set --subscription $subscription_id
 
     echo "Using the following subscription:"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -72,7 +72,7 @@ if [ "$#" -eq 4 ]; then
     TF_IN_AUTOMATION=1 terraform apply --auto-approve -var-file=./bootstrap_backend.tfvars
     
 elif [ "$#" -eq 0 ]; then
-   az login --allow-no-subscriptions
+   az login --allow-no-subscriptions --use-device-code
    pushd ./tenant-configuration
 
    # Disable AzureRM backend in the main.tf file


### PR DESCRIPTION
This pull request primarily focuses on enhancing the login process in the `bootstrap/bootstrap.sh` script. The changes involve modifying the `az login` command to use device code for authentication, which is a more secure method.

Here are the key changes:

* [`bootstrap/bootstrap.sh`](diffhunk://#diff-d3cdbc0e4f313c8e281d50203043b86bd81bddf1463cff682a35d1d447205220L39-R39): Updated the `az login` command in the `if [ "$#" -eq 4 ]; then` block to use device code for authentication. This change makes the login process more secure by requiring a device code.
* [`bootstrap/bootstrap.sh`](diffhunk://#diff-d3cdbc0e4f313c8e281d50203043b86bd81bddf1463cff682a35d1d447205220L75-R75): Similarly, in the `elif [ "$#" -eq 0 ]; then` block, the `az login --allow-no-subscriptions` command was updated to also use device code for authentication. This ensures a secure login process even when no subscriptions are allowed.