### PR TITLE
VM username should not be hardcoded

### DIFF
--- a/quickstarts/301-sap-gateway/gateway-vm/main.tf
+++ b/quickstarts/301-sap-gateway/gateway-vm/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_windows_virtual_machine" "vm-opgw" {
 
   # rest of the resource block
   size                                                   = "Standard_D4s_v5"
-  admin_username                                         = "sapadmin"
+  admin_username                                         = var.vm_user
   admin_password                                         = var.vm_pwd
   computer_name                                          = "vmopgw"
   enable_automatic_updates                               = true

--- a/quickstarts/301-sap-gateway/gateway-vm/variables.tf
+++ b/quickstarts/301-sap-gateway/gateway-vm/variables.tf
@@ -20,6 +20,12 @@ variable "region" {
   type        = string
 }
 
+variable "vm_user" {
+  description = "The user name for the VM"
+  sensitive   = true
+  type        = string
+}
+
 variable "vm_pwd" {
   description = "The password for the VM"
   sensitive   = true

--- a/quickstarts/301-sap-gateway/main.tf
+++ b/quickstarts/301-sap-gateway/main.tf
@@ -264,7 +264,7 @@ resource "azurerm_key_vault_secret" "key_vault_secret_recover_key" {
 }
 
 resource "random_string" "vm_user" {
-  length  = 20
+  length  = 20 # minimum 1, maximum 20
   special = false
   numeric = true
 }

--- a/quickstarts/301-sap-gateway/main.tf
+++ b/quickstarts/301-sap-gateway/main.tf
@@ -264,8 +264,8 @@ resource "azurerm_key_vault_secret" "key_vault_secret_recover_key" {
 }
 
 resource "random_string" "vm_user" {
-  length  = 12
-  special = true
+  length  = 64
+  special = false
   numeric = true
 }
 
@@ -287,7 +287,7 @@ resource "azurerm_key_vault_secret" "key_vault_secret_vm_user" {
 }
 
 resource "random_string" "vm_pwd" {
-  length  = 32
+  length  = 64
   special = true
   numeric = true
 }

--- a/quickstarts/301-sap-gateway/main.tf
+++ b/quickstarts/301-sap-gateway/main.tf
@@ -263,6 +263,29 @@ resource "azurerm_key_vault_secret" "key_vault_secret_recover_key" {
   tags            = var.tags
 }
 
+resource "random_string" "vm_user" {
+  length  = 12
+  special = true
+  numeric = true
+}
+
+resource "azurecaf_name" "key_vault_secret_vm_user" {
+  name          = "vm-user"
+  resource_type = "azurerm_key_vault_secret"
+  prefixes      = [var.prefix]
+  random_length = 3
+  clean_input   = true
+}
+
+resource "azurerm_key_vault_secret" "key_vault_secret_vm_user" {
+  name            = azurecaf_name.key_vault_secret_vm_user.result
+  value           = random_string.vm_user.result
+  key_vault_id    = azurerm_key_vault.key_vault.id
+  expiration_date = "2024-12-30T20:00:00Z"
+  content_type    = "text/plain"
+  tags            = var.tags
+}
+
 resource "random_string" "vm_pwd" {
   length  = 32
   special = true
@@ -299,6 +322,7 @@ module "gateway_vm" {
   resource_group_name        = azurerm_resource_group.rg.name
   base_name                  = var.base_name
   region                     = var.region_gw
+  vm_user                    = random_string.vm_user.result
   vm_pwd                     = random_string.vm_pwd.result
   nic_id                     = azurerm_network_interface.nic.id
   client_id_pp               = var.client_id_pp

--- a/quickstarts/301-sap-gateway/main.tf
+++ b/quickstarts/301-sap-gateway/main.tf
@@ -264,7 +264,7 @@ resource "azurerm_key_vault_secret" "key_vault_secret_recover_key" {
 }
 
 resource "random_string" "vm_user" {
-  length  = 64
+  length  = 20
   special = false
   numeric = true
 }


### PR DESCRIPTION
This pull request includes several changes to improve the security and configuration of the Azure resources in the SAP Gateway setup. The most important changes involve replacing hardcoded values with variables, generating secure random strings for sensitive data, and updating resource configurations to use these new variables.
 
### Security Improvements:
* [`quickstarts/301-sap-gateway/gateway-vm/main.tf`](diffhunk://#diff-e96c12c97047659308abe39370457aebc295f56dac77fc30dcd5b7c1e81106d1L99-R99): Replaced the hardcoded `admin_username` with `var.vm_user` for better security and flexibility.
* [`quickstarts/301-sap-gateway/main.tf`](diffhunk://#diff-07eadf8e4ccee013fd99aee3e4703d3e606d6c4631623a822b7ed4b009d5da2bR266-R290): Added a new `random_string` resource to generate a secure random username for the VM and a corresponding `azurerm_key_vault_secret` to store it securely.
 
### Configuration Enhancements:
* [`quickstarts/301-sap-gateway/gateway-vm/variables.tf`](diffhunk://#diff-9bffe2ae4625cede96106c2bd16ec4169940289cfefb2d5f1e3915089d9e4865R23-R28): Introduced a new variable `vm_user` for the VM username, marked as sensitive.
* [`quickstarts/301-sap-gateway/main.tf`](diffhunk://#diff-07eadf8e4ccee013fd99aee3e4703d3e606d6c4631623a822b7ed4b009d5da2bR325): Updated the `module "gateway_vm"` to use the new `random_string.vm_user.result` for the VM username.
* [`quickstarts/301-sap-gateway/main.tf`](diffhunk://#diff-07eadf8e4ccee013fd99aee3e4703d3e606d6c4631623a822b7ed4b009d5da2bR266-R290): Increased the length of the `random_string` for `vm_pwd` to 64 characters for enhanced security.


Fix #95 