### PR TITLE
Update SAP .NET Connector version and installation method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ tfchecov.sh
 *.locl.hcl
 
 # SAP installation files
-sapnco.msi
+sapnco.exe

--- a/quickstarts/301-sap-gateway/README.md
+++ b/quickstarts/301-sap-gateway/README.md
@@ -27,7 +27,7 @@ The subnet ID is available at the JSON view of the virtual network, in the param
 
 ### Storage Account Preparation
 
-Before you execute the script, you need to upload the SAP .NET Connector MSI file the folder `./storage-account/sapnco-msi` and rename to `sapnco.msi` (check below for more information).
+Before you execute the script, you need to upload the SAP .NET Connector executable file the folder `./storage-account/sapnco` and rename to `sapnco.exe` (check below for more information).
 
 ### SHIR Nodes Preparation
 
@@ -41,7 +41,7 @@ The example files can be found in `quickstarts/301-sap-gateway`
 
 The Terraform plugins or "providers" that this IaC deployment requires are:
 
-- **azurecaf (`aztfmod/azurecaf`):** `>=1.2.26`
+- **azurecaf (`aztfmod/azurecaf`):** `>=1.2.28`
 
 - **azurerm (`hashicorp/azurerm`):** `>=3.74.0`
 

--- a/quickstarts/301-sap-gateway/README.md.tmpl
+++ b/quickstarts/301-sap-gateway/README.md.tmpl
@@ -26,7 +26,7 @@ The subnet ID is available at the JSON view of the virtual network, in the param
 
 ### Storage Account Preparation
 
-Before you execute the script, you need to upload the SAP .NET Connector MSI file the folder `./storage-account/sapnco-msi` and rename to `sapnco.msi` (check below for more information).
+Before you execute the script, you need to upload the SAP .NET Connector executable file the folder `./storage-account/sapnco` and rename to `sapnco.exe` (check below for more information).
 
 ### SHIR Nodes Preparation
 

--- a/quickstarts/301-sap-gateway/gateway-vm/sapnco-install/main.tf
+++ b/quickstarts/301-sap-gateway/gateway-vm/sapnco-install/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 resource "azurerm_gallery_application" "sapnco-install-igl-app" {
-  name              = "sapnco.msi"
+  name              = "sapnco-install"
   gallery_id        = var.sig_id
   location          = var.region
   supported_os_type = "Windows"
@@ -20,7 +20,7 @@ resource "azurerm_gallery_application_version" "sapnco-install-igl-app-version" 
   location               = var.region
 
   manage_action {
-    install = "msiexec /i sapnco.msi /qn /norestart FolderForm_AllUsers=ALL GAC_WMI=2 /log install.log"
+    install = "sapnco.exe /Silent"
     remove  = "echo" # Uninstall script is not applicable.
   }
 

--- a/quickstarts/301-sap-gateway/storage-account/main.tf
+++ b/quickstarts/301-sap-gateway/storage-account/main.tf
@@ -78,11 +78,11 @@ resource "azurerm_storage_blob" "storage_blob_java_runtime" {
 }
 
 resource "azurerm_storage_blob" "storage_blob_sapnco_install" {
-  name                   = "sapnco.msi"
+  name                   = "sapnco.exe"
   storage_account_name   = azurerm_storage_account.storage_account.name
   storage_container_name = azurerm_storage_container.storage_container_installs.name
   type                   = "Block"
-  source                 = "./storage-account/sapnco-msi/sapnco.msi"
+  source                 = "./storage-account/sapnco/sapnco.exe"
 }
 
 resource "azurerm_storage_blob" "storage_blob_runtime_setup" {

--- a/quickstarts/301-sap-gateway/storage-account/sapnco-msi/README.md
+++ b/quickstarts/301-sap-gateway/storage-account/sapnco-msi/README.md
@@ -1,1 +1,0 @@
-# Place the SAP .Net Connector MSI in this folder

--- a/quickstarts/301-sap-gateway/storage-account/sapnco/README.md
+++ b/quickstarts/301-sap-gateway/storage-account/sapnco/README.md
@@ -1,0 +1,1 @@
+# Place the SAP .Net Connector executable file in this folder


### PR DESCRIPTION
This pull request includes updates to the SAP Gateway quickstart documentation and Terraform scripts to replace the SAP .NET Connector MSI file with an executable file. The most important changes include updates to file paths, installation commands, and documentation references.

Updates to file paths and installation commands:

* [`quickstarts/301-sap-gateway/gateway-vm/sapnco-install/main.tf`](diffhunk://#diff-88a33f758f5030dd65f11973173f0ac1d3cff673459a954aac3415f9786a9413L11-R11): Changed the `azurerm_gallery_application` resource name from `sapnco.msi` to `sapnco-install` and updated the installation command to use `sapnco.exe`. [[1]](diffhunk://#diff-88a33f758f5030dd65f11973173f0ac1d3cff673459a954aac3415f9786a9413L11-R11) [[2]](diffhunk://#diff-88a33f758f5030dd65f11973173f0ac1d3cff673459a954aac3415f9786a9413L23-R23)
* [`quickstarts/301-sap-gateway/storage-account/main.tf`](diffhunk://#diff-5a3b4ab69dde40f6e03461d675ac17b38b39f45b891264f72e9f8a0b32592222L81-R85): Updated the storage blob resource to use `sapnco.exe` instead of `sapnco.msi` and changed the source path accordingly.

Documentation updates:

* [`quickstarts/301-sap-gateway/README.md`](diffhunk://#diff-79871ad680d89967f1363e89b3a2cd45e670349857a50aecb2ea4dbdd2e5b1bcL30-R30): Updated references to the SAP .NET Connector file, changing from MSI to executable, and updated the required version for the `azurecaf` provider. [[1]](diffhunk://#diff-79871ad680d89967f1363e89b3a2cd45e670349857a50aecb2ea4dbdd2e5b1bcL30-R30) [[2]](diffhunk://#diff-79871ad680d89967f1363e89b3a2cd45e670349857a50aecb2ea4dbdd2e5b1bcL44-R44)
* [`quickstarts/301-sap-gateway/README.md.tmpl`](diffhunk://#diff-fb85ec789a4b0ced65847fb60afde0d1759f3a0d4eb12ed207467cc2ce012c4cL29-R29): Made similar updates to the README template as in the main README file.
* [`quickstarts/301-sap-gateway/storage-account/sapnco/README.md`](diffhunk://#diff-f12c9a1baca5c52c812b58cc4f2691fb2c9383aa49dd23cecf79917f8bba3c4dR1): Added instructions to place the SAP .NET Connector executable file in the specified folder.

Removed outdated documentation:

* [`quickstarts/301-sap-gateway/storage-account/sapnco-msi/README.md`](diffhunk://#diff-7c3e1387786a01d60be847220f3639f3515daddc853e0b9aab72c3bad633865bL1): Removed the outdated README file for the MSI version of the SAP .NET Connector.