### PR TITLE
132-Update the shir installation link

### DIFF
--- a/quickstarts/301-sap-gateway/storage-account/scripts/runtime-setup.ps1
+++ b/quickstarts/301-sap-gateway/storage-account/scripts/runtime-setup.ps1
@@ -72,7 +72,7 @@ if($Psversion.Major -ge 7)
 
     # Define the download URL for the MSI installer.
     # Please, update the version number to the latest version.
-    $downloadUrl = "https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_5.32.8600.2.msi"
+    $downloadUrl = "https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_5.43.8935.2.msi"
 
     # Define the path where the installer will be downloaded.
     $installerPath = "C:\sapint\IntegrationRuntime.msi"


### PR DESCRIPTION
This pull request includes a small change to the `quickstarts/301-sap-gateway/storage-account/scripts/runtime-setup.ps1` file. The change updates the download URL for the MSI installer to the latest version.

* [`quickstarts/301-sap-gateway/storage-account/scripts/runtime-setup.ps1`](diffhunk://#diff-8e0f1f1c4ca287fb22b8a5df9bbd68fbf8c28825d85ef22830f5ef756e1022fbL75-R75): Updated the download URL for the MSI installer to version 5.43.8935.2.

It solves the issue #132 