### PR TITLE
Update Power Platform provider version to >=3.3.0 in quickstart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ The example terraform modules are intended to be run by GitHub Actions, however 
 2. Try out any of the following **Quickstart Examples**
 
 ## Quickstart Examples
-* [301-sap-gateway](./quickstarts/301-sap-gateway/README.md)
-* [201-D365-finance-environment](./quickstarts/201-D365-finance-environment/README.md)
-* [102-github-pipeline](./quickstarts/102-github-pipeline/README.md)
 * [300-pac-checkov](./quickstarts/300-pac-checkov/README.md)
-* [103-demo-tenant](./quickstarts/103-demo-tenant/README.md)
+* [201-D365-finance-environment](./quickstarts/201-D365-finance-environment/README.md)
 * [101-hello-power-platform](./quickstarts/101-hello-power-platform/README.md)
+* [301-sap-gateway](./quickstarts/301-sap-gateway/README.md)
+* [103-demo-tenant](./quickstarts/103-demo-tenant/README.md)
+* [102-github-pipeline](./quickstarts/102-github-pipeline/README.md)
 
 Quickstarts use the Power-Platform provider, documentation can be found [here](https://microsoft.github.io/terraform-provider-power-platform/).

--- a/quickstarts/101-hello-power-platform/README.md
+++ b/quickstarts/101-hello-power-platform/README.md
@@ -21,7 +21,7 @@ The Terraform plugins or "providers" that this IaC deployment requires are:
 
 - **null (`hashicorp/null`):** (any version)
 
-- **powerplatform (`microsoft/power-platform`):** `>=2.0.2-preview`
+- **powerplatform (`microsoft/power-platform`):** `>=3.3.0`
 
 - **random (`hashicorp/random`):** (any version)
 

--- a/quickstarts/101-hello-power-platform/main.tf
+++ b/quickstarts/101-hello-power-platform/main.tf
@@ -11,7 +11,7 @@ terraform {
     }
     powerplatform = {
       source  = "microsoft/power-platform"
-      version = ">=2.0.2-preview"
+      version = ">=3.3.0"
     }
   }
 }

--- a/quickstarts/101-hello-power-platform/power-platform/main.tf
+++ b/quickstarts/101-hello-power-platform/power-platform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     powerplatform = {
       source  = "microsoft/power-platform"
-      version = ">=2.0.2-preview"
+       version = ">=3.3.0"
     }
   }
 }

--- a/quickstarts/102-github-pipeline/README.md
+++ b/quickstarts/102-github-pipeline/README.md
@@ -19,7 +19,7 @@ The example files can be found in `quickstarts/102-github-pipeline`
 
 The Terraform plugins or "providers" that this IaC deployment requires are:
 
-- **powerplatform (`microsoft/power-platform`):** (any version)
+- **powerplatform (`microsoft/power-platform`):** `>=3.3.0`
 
 ## Resources
 

--- a/quickstarts/102-github-pipeline/main.tf
+++ b/quickstarts/102-github-pipeline/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     powerplatform = {
       source  = "microsoft/power-platform"
+      version = ">=3.3.0"
     }
   }
 

--- a/quickstarts/201-D365-finance-environment/main.tf
+++ b/quickstarts/201-D365-finance-environment/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     powerplatform = {
       source = "microsoft/power-platform"
-      version = "~>3.1"
+      version = ">=3.3.0"
     }
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `README.md` files and Terraform configuration files across multiple quickstart examples to ensure consistency and compatibility with the latest version of the `power-platform` provider.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R48): Reordered the quickstart examples for better organization.
* [`quickstarts/101-hello-power-platform/README.md`](diffhunk://#diff-27e82094f01744232c9fa8611323a24d4bd3aa802753737b6817069b2c5c0089L24-R24): Updated the required version of the `power-platform` provider to `>=3.3.0`.
* [`quickstarts/102-github-pipeline/README.md`](diffhunk://#diff-408481020dc6e042e7fbe22b9906755fb96a6c43082af32744af978c238fec39L22-R22): Updated the required version of the `power-platform` provider to `>=3.3.0`.

### Terraform configuration updates:
* [`quickstarts/101-hello-power-platform/main.tf`](diffhunk://#diff-06dda5bb936585f63f737197392fac98bae2e913b568de5344c4b32fe18531acL14-R14): Updated the `power-platform` provider version to `>=3.3.0`.
* [`quickstarts/101-hello-power-platform/power-platform/main.tf`](diffhunk://#diff-ce020c70654b8d36668b72f737b605e7d1c7ea492f4e55731286a895e2d9533fL5-R5): Updated the `power-platform` provider version to `>=3.3.0`.
* [`quickstarts/102-github-pipeline/main.tf`](diffhunk://#diff-ec97685a92e1ba347210ec4d7c528f2026d84bf6828053e7a29e4fc88388cfc0R5): Specified the `power-platform` provider version as `>=3.3.0`.
* [`quickstarts/201-D365-finance-environment/main.tf`](diffhunk://#diff-f878608250e97c8dc26d78e23ffbb19b52059b161bb49f1307a08206f59da85fL6-R6): Updated the `power-platform` provider version to `>=3.3.0`.